### PR TITLE
Handle new response of relayed V3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-network-providers",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-network-providers",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "bech32": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-network-providers",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "author": "MultiversX",

--- a/src/providers.dev.net.spec.ts
+++ b/src/providers.dev.net.spec.ts
@@ -243,29 +243,7 @@ describe("test network providers on devnet: Proxy and API", function () {
         const apiResponse = await apiProvider.getTransaction(txHash);
         const proxyResponse = await proxyProvider.getTransaction(txHash, true);
 
-        assert.deepEqual(proxyResponse.innerTransactions, [
-            {
-                nonce: BigInt(9340),
-                value: BigInt("1000000000000000000"),
-                receiver: "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
-                sender: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
-                data: Buffer.from([]),
-                gasPrice: BigInt(1000000000),
-                gasLimit: BigInt(50000),
-                chainID: "D",
-                version: 2,
-                signature: Buffer.from(
-                    "0993c2f3a47c01cf8330e54571ea9340aae481d0d5212af31b62eb7194e199231f105134aae28a75bb48b53a3dff09d6c6208843c8e0376617cf62d3bfb60204",
-                    "hex",
-                ),
-                senderUsername: "",
-                receiverUsername: "",
-                guardian: "",
-                guardianSignature: Buffer.from([]),
-                options: 0,
-                relayer: "erd1r69gk66fmedhhcg24g2c5kn2f2a5k4kvpr6jfw67dn2lyydd8cfswy6ede",
-            },
-        ]);
+        assert.lengthOf(proxyResponse.innerTransactions, 1);
 
         ignoreKnownTransactionDifferencesBetweenProviders(apiResponse, proxyResponse);
         assert.deepEqual(apiResponse, proxyResponse);

--- a/src/proxyNetworkProvider.ts
+++ b/src/proxyNetworkProvider.ts
@@ -103,20 +103,30 @@ export class ProxyNetworkProvider implements INetworkProvider {
         return tokenData;
     }
 
-    async getTransaction(txHash: string, withProcessStatus?: boolean): Promise<TransactionOnNetwork> {
+    async getTransaction(
+        txHash: string,
+        withProcessStatus?: boolean,
+        relayedTxHash?: string,
+    ): Promise<TransactionOnNetwork> {
         let processStatusPromise: Promise<TransactionStatus> | undefined;
 
         if (withProcessStatus === true) {
             processStatusPromise = this.getTransactionStatus(txHash);
         }
 
-        let url = this.buildUrlWithQueryParameters(`transaction/${txHash}`, { withResults: "true" });
+        const parameters: any = {
+            withResults: "true",
+            ...(relayedTxHash && { relayedTxHash }),
+        };
+
+        let url = this.buildUrlWithQueryParameters(`transaction/${txHash}`, parameters);
         let response = await this.doGetGeneric(url);
 
         if (processStatusPromise) {
             const processStatus = await processStatusPromise;
             return TransactionOnNetwork.fromProxyHttpResponse(txHash, response.transaction, processStatus);
         }
+
         return TransactionOnNetwork.fromProxyHttpResponse(txHash, response.transaction);
     }
 

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -71,6 +71,10 @@ export class TransactionOnNetwork {
             result.isCompleted = result.status.isSuccessful() || result.status.isFailed();
         }
 
+        result.innerTransactions = (response.innerTransactions || []).map((item: any) =>
+            TransactionOnNetwork.fromProxyHttpResponse(item.hash, item),
+        );
+
         return result;
     }
 
@@ -78,6 +82,11 @@ export class TransactionOnNetwork {
         let result = TransactionOnNetwork.fromHttpResponse(txHash, response);
         result.contractResults = ContractResults.fromApiHttpResponse(response.results || []);
         result.isCompleted = !result.status.isPending();
+
+        result.innerTransactions = (response.innerTransactions || []).map((item: any) =>
+            TransactionOnNetwork.fromApiHttpResponse(item.hash, item),
+        );
+
         return result;
     }
 
@@ -105,31 +114,8 @@ export class TransactionOnNetwork {
 
         result.receipt = TransactionReceipt.fromHttpResponse(response.receipt || {});
         result.logs = TransactionLogs.fromHttpResponse(response.logs || {});
-        result.innerTransactions = (response.innerTransactions || []).map(this.innerTransactionFromHttpResource);
 
         return result;
-    }
-
-    private static innerTransactionFromHttpResource(resource: any): ITransactionNext {
-        return {
-            nonce: BigInt(resource.nonce || 0),
-            value: BigInt(resource.value || 0),
-            receiver: resource.receiver,
-            sender: resource.sender,
-            // We discard "senderUsername" and "receiverUsername" (to avoid future discrepancies between Proxy and API):
-            senderUsername: "",
-            receiverUsername: "",
-            gasPrice: BigInt(resource.gasPrice),
-            gasLimit: BigInt(resource.gasLimit),
-            data: Buffer.from(resource.data || "", "base64"),
-            chainID: resource.chainID,
-            version: resource.version,
-            options: resource.options || 0,
-            guardian: resource.guardian || "",
-            signature: Buffer.from(resource.signature, "hex"),
-            guardianSignature: resource.guardianSignature ? Buffer.from(resource.guardianSignature, "hex") : Buffer.from([]),
-            relayer: resource.relayer,
-        };
     }
 
     getDateTime(): Date {


### PR DESCRIPTION
This isn't a breaking change per-se, since Relayed V3 isn't active on Mainnet. Additionally, the previous deployment on Devnet contained a few issues.

Related:
 - https://github.com/multiversx/mx-chain-proxy-go/pull/465
 - https://github.com/multiversx/mx-chain-go/pull/6529

If one wants to retrieve a Relayed (V3) with its inner transactions, she should simply do:

```
const transaction = networkProvider.getTransaction(hashOfParentTransaction);
console.log(transaction.innerTransactions);
```

Alternatively, if one wants to retrieve only an inner transaction, she must specify both the hash of the inner transaction, and the hash of the parent transaction:

```
// API is somehow cumbersome, kept this way to avoid breaking changes.
const transaction = networkProvider.getTransaction(hashOfInnerTransaction, false, hashOfParentTransaction);
```