### PR TITLE
Temporary workaround (hotfix): do not call "extendUserAgent"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-network-providers",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-network-providers",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "license": "MIT",
       "dependencies": {
         "bech32": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-network-providers",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "author": "MultiversX",

--- a/src/apiNetworkProvider.ts
+++ b/src/apiNetworkProvider.ts
@@ -32,7 +32,6 @@ export class ApiNetworkProvider implements INetworkProvider {
         let proxyConfig = this.getProxyConfig(config);
         this.config = { ...defaultAxiosConfig, ...config };
         this.backingProxyNetworkProvider = new ProxyNetworkProvider(url, proxyConfig);
-        extendUserAgent(this.userAgentPrefix, this.config);
     }
 
     private getProxyConfig(config: NetworkProviderConfig | undefined) {

--- a/src/providers.dev.net.spec.ts
+++ b/src/providers.dev.net.spec.ts
@@ -36,7 +36,7 @@ describe("test network providers on devnet: Proxy and API", function () {
         assert.deepEqual(apiResponse, proxyResponse);
     });
 
-    it("should add userAgent unknown for clientName when no clientName passed", async function () {
+    it.skip("should add userAgent unknown for clientName when no clientName passed", async function () {
         const expectedApiUserAgent = "multiversx-sdk/api/unknown"
         const expectedProxyUserAgent = "multiversx-sdk/proxy/unknown"
 
@@ -47,7 +47,7 @@ describe("test network providers on devnet: Proxy and API", function () {
         assert.equal(localProxyProvider.config.headers.getUserAgent(), expectedProxyUserAgent);
     });
 
-    it("should set userAgent with specified clientName ", async function () {
+    it.skip("should set userAgent with specified clientName ", async function () {
         const expectedApiUserAgent = "multiversx-sdk/api/test"
         const expectedProxyUserAgent = "multiversx-sdk/proxy/test"
 
@@ -58,7 +58,7 @@ describe("test network providers on devnet: Proxy and API", function () {
         assert.equal(localProxyProvider.config.headers.getUserAgent(), expectedProxyUserAgent);
     });
 
-    it("should keep the set userAgent and add the sdk to it", async function () {
+    it.skip("should keep the set userAgent and add the sdk to it", async function () {
         const expectedApiUserAgent = "Client-info multiversx-sdk/api/test"
         const expectedProxyUserAgent = "Client-info multiversx-sdk/proxy/test"
 

--- a/src/proxyNetworkProvider.ts
+++ b/src/proxyNetworkProvider.ts
@@ -26,7 +26,6 @@ export class ProxyNetworkProvider implements INetworkProvider {
     constructor(url: string, config?: NetworkProviderConfig) {
         this.url = url;
         this.config = { ...defaultAxiosConfig, ...config };
-        extendUserAgent(this.userAgentPrefix, this.config);
     }
 
     async getNetworkConfig(): Promise<NetworkConfig> {


### PR DESCRIPTION
Temporary workaround (hotfix): do not call `extendUserAgent`, until a complete solution is found.